### PR TITLE
fix: correctly casting historyJson in photo repository query

### DIFF
--- a/src/main/java/com/chaptime/backend/repository/PhotoRepository.java
+++ b/src/main/java/com/chaptime/backend/repository/PhotoRepository.java
@@ -33,7 +33,7 @@ public interface PhotoRepository extends JpaRepository<Photo, UUID> {
     SELECT DISTINCT ph.*
     FROM
         photos ph,
-        jsonb_to_recordset(:historyJson::jsonb) AS h(latitude float, longitude float, "timestamp" timestamptz)
+        jsonb_to_recordset(cast(:historyJson as jsonb)) AS h(latitude float, longitude float, "timestamp" timestamptz)
     WHERE
         ph.place_id = :placeId
         AND ph.visibility = 'PUBLIC'


### PR DESCRIPTION
This change should fix the error: `org.hibernate.query.UnknownParameterException: No parameter named ':historyJson' in query with named parameters [placeId, historyJson::jsonb]` received when calling the API endpoint `/api/v1/feed/historical` by correctly casting the `historyJson` parameter.